### PR TITLE
Add support for Julia functions

### DIFF
--- a/FaaSr_py/FaaSr.schema.json
+++ b/FaaSr_py/FaaSr.schema.json
@@ -75,7 +75,8 @@
               "type": "string",
               "enum": [
                 "Python",
-                "R"
+                "R",
+                "Julia"
               ]
             },
             "RequiresVM": {

--- a/FaaSr_py/FaaSr.schema.json
+++ b/FaaSr_py/FaaSr.schema.json
@@ -579,6 +579,22 @@
         }
       }
     },
+    "JuliaPkgPackage": {
+      "description": "User Pkg packages",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "minLength": 1
+      },
+      "patternProperties": {
+        "": {
+          "type": [
+            "string",
+            "array"
+          ]
+        }
+      }
+    },
     "FunctionGitHubPackage": {
       "description": "User packages from github Repository",
       "type": "object",

--- a/FaaSr_py/client/julia_client_stubs.jl
+++ b/FaaSr_py/client/julia_client_stubs.jl
@@ -2,16 +2,18 @@ using Base
 import HTTP
 import JSON
 
+# Parse the response and check for 'success' field
 function parse_response(res, rpc_id)
     res_body = String(res.body)
     if get(JSON.parse(res_body), "Success", false)
-        exit(0)
+        return true
     else
         err_msg = "{\"$rpc_id\": \"Request to FaaSr RPC failed\"}"
         println(err_msg)
         exit(1)
     end
 end
+
 
 function handle_response_error(e, rpc_id)
     if isa(e, HTTP.ExceptionRequest.StatusError)
@@ -45,6 +47,7 @@ function faasr_put_file(local_file, remote_file, server_name="", local_folder=".
     end
 end
 
+
 function faasr_get_file(local_file, remote_file, server_name="", local_folder=".", remote_folder=".")
     rpc_id="faasr_get_file"
     request_json = Dict(
@@ -66,6 +69,7 @@ function faasr_get_file(local_file, remote_file, server_name="", local_folder=".
     end
 end
 
+
 function faasr_delete_file(remote_file, server_name="", remote_folder=".")
     rpc_id="faasr_delete_file"
     request_json = Dict(
@@ -85,6 +89,7 @@ function faasr_delete_file(remote_file, server_name="", remote_folder=".")
     end
 end
 
+
 function faasr_log(log_message)
     if (log_message == nothing || log_message == "")
         err_msg = "{\"faasr_log\": \"ERROR -- empty log_message not allowed\"}"
@@ -99,12 +104,13 @@ function faasr_log(log_message)
     )
 
     try
-        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(return_json))
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
         parse_response(res, rpc_id)
     catch e
         handle_response_error(e, rpc_id)
     end
 end
+
 
 function faasr_get_folder_list(server_name="", prefix="")
     rpc_id="faasr_get_folder_list"
@@ -118,7 +124,59 @@ function faasr_get_folder_list(server_name="", prefix="")
 
     try
         res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
-        parse_response(res, rpc_id)
+        body = JSON.parse(String(res.body))
+        return body["Data"]["folder_list"] 
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+
+function faasr_rank()
+    rpc_id="faasr_rank"
+    request_json = Dict(
+        "ProcedureID"=>rpc_id,
+        "Arguments"=>Dict()
+    )
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
+        body = JSON.parse(String(res.body))
+        return body["Data"]
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+
+function faasr_get_s3_creds()
+    rpc_id="faasr_get_s3_creds"
+    request_json = Dict(
+        "ProcedureID"=>rpc_id,
+        "Arguments"=>Dict()
+    )
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
+        body = JSON.parse(String(res.body))
+        return body["Data"]["s3_creds"]
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+
+function faasr_invocation_id()
+    rpc_id="faasr_invocation_id"
+    request_json = Dict(
+        "ProcedureID"=>rpc_id,
+        "Arguments"=>Dict()
+    )
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
+        body = JSON.parse(String(res.body))
+        return body["Data"]["invocation_id"]
     catch e
         handle_response_error(e, rpc_id)
     end
@@ -130,7 +188,7 @@ function faasr_return(return_value=nothing)
     rpc_id="faasr_return"
 
     try
-        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(return_json))
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-return", [], JSON.json(return_json))
         parse_response(res, rpc_id)
     catch e
         handle_response_error(e, rpc_id)
@@ -142,7 +200,7 @@ function faasr_exit(message=nothing, error=true)
     rpc_id="faasr_exit"
 
     try
-        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(exit_json))
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-exit", [], JSON.json(exit_json))
         parse_response(res, rpc_id)
     catch e
         handle_response_error(e, rpc_id)

--- a/FaaSr_py/client/julia_client_stubs.jl
+++ b/FaaSr_py/client/julia_client_stubs.jl
@@ -1,0 +1,150 @@
+using Base
+import HTTP
+import JSON
+
+function parse_response(res, rpc_id)
+    res_body = String(res.body)
+    if get(JSON.parse(res_body), "Success", false)
+        exit(0)
+    else
+        err_msg = "{\"$rpc_id\": \"Request to FaaSr RPC failed\"}"
+        println(err_msg)
+        exit(1)
+    end
+end
+
+function handle_response_error(e, rpc_id)
+    if isa(e, HTTP.ExceptionRequest.StatusError)
+        err_msg = "{{\"$rpc_id\": \"HTTP request returned an exception:\n$(e.response) ($(e.status))\"}}"
+    else
+        err_msg = "{{\"$rpc_id\": \"Error making request to RPC server: $(typeof(e)): $e\"}}"
+    end
+    println(err_msg)
+    exit(1)
+end
+
+
+function faasr_put_file(local_file, remote_file, server_name="", local_folder=".", remote_folder=".")
+    rpc_id="faasr_put_file"
+    request_json = Dict(
+        "ProcedureID"=>rpc_id,
+        "Arguments"=>Dict(
+            "local_file"=>string(local_file),
+            "remote_file"=>string(remote_file),
+            "server_name"=>server_name,
+            "local_folder"=>string(local_folder),
+            "remote_folder"=>string(remote_folder) 
+        )
+    )
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
+        parse_response(res, rpc_id)
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+function faasr_get_file(local_file, remote_file, server_name="", local_folder=".", remote_folder=".")
+    rpc_id="faasr_get_file"
+    request_json = Dict(
+        "ProcedureID"=>rpc_id,
+        "Arguments"=>Dict(
+            "local_file"=>string(local_file),
+            "remote_file"=>string(remote_file),
+            "server_name"=>server_name,
+            "local_folder"=>string(local_folder),
+            "remote_folder"=>string(remote_folder) 
+        )
+    )
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
+        parse_response(res, rpc_id)
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+function faasr_delete_file(remote_file, server_name="", remote_folder=".")
+    rpc_id="faasr_delete_file"
+    request_json = Dict(
+        "ProcedureID"=>rpc_id,
+        "Arguments"=>Dict(
+            "remote_file"=>string(remote_file),
+            "server_name"=>server_name,
+            "remote_folder"=>string(remote_folder) 
+        )
+    )
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
+        parse_response(res, rpc_id)
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+function faasr_log(log_message)
+    if (log_message == nothing || log_message == "")
+        err_msg = "{\"faasr_log\": \"ERROR -- empty log_message not allowed\"}"
+        println(err_msg)
+        exit(1)
+    end
+    
+    rpc_id="faasr_log"
+    request_json = Dict(
+        "ProcedureID"=>rpc_id,
+        "Arguments"=>Dict("log_message"=>log_message)
+    )
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(return_json))
+        parse_response(res, rpc_id)
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+function faasr_get_folder_list(server_name="", prefix="")
+    rpc_id="faasr_get_folder_list"
+    request_json = Dict(
+        "ProcedureID"=>rpc_id,
+        "Arguments"=>Dict(
+            "server_name"=>server_name,
+            "prefix"=>string(prefix) 
+        )
+    )
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(request_json))
+        parse_response(res, rpc_id)
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+
+function faasr_return(return_value=nothing)
+    return_json = Dict("FunctionResult"=>return_value)
+    rpc_id="faasr_return"
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(return_json))
+        parse_response(res, rpc_id)
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end
+
+function faasr_exit(message=nothing, error=true)
+    exit_json = Dict("Error"=>error, "Message"=>message)
+    rpc_id="faasr_exit"
+
+    try
+        res = HTTP.request("POST","http://127.0.0.1:8000/faasr-action", [], JSON.json(exit_json))
+        parse_response(res, rpc_id)
+    catch e
+        handle_response_error(e, rpc_id)
+    end
+end

--- a/FaaSr_py/client/julia_func_helper.jl
+++ b/FaaSr_py/client/julia_func_helper.jl
@@ -1,0 +1,29 @@
+import Base
+
+function faasr_import_function_walk(func_name, directory=".")
+    ignore_files = [
+        "julia_func_helper.jl",
+        "julia_user_func_entry.jl"
+    ]
+
+    fn = Symbol(func_name)
+
+    for (path, dirs, files) in Base.Filesystem.walkdir(directory)
+        for file in files
+            if Base.endswith(file, ".jl") && !(file in ignore_files)
+                include("$path/$file")
+                println("included $path/$file")
+                try
+                    println("function $func_name: $(isdefined(Main, fn))")
+                    if isdefined(Main, fn)
+                        return fn
+                    end
+                catch e
+                end
+            end
+        end
+    end
+    return nothing
+
+end
+

--- a/FaaSr_py/client/julia_func_helper.jl
+++ b/FaaSr_py/client/julia_func_helper.jl
@@ -1,22 +1,36 @@
 import Base
 
+#==
+# Searches recursively for julia files starting in directory and includes them 
+# Returns a symbol storing the name of user_func if successful 
+# Returns nothing if func_name is not found
+=#
+
 function faasr_import_function_walk(func_name, directory=".")
     ignore_files = [
+        "julia_client_stubs.jl",
         "julia_func_helper.jl",
         "julia_user_func_entry.jl"
     ]
 
     fn = Symbol(func_name)
 
+
     for (path, dirs, files) in Base.Filesystem.walkdir(directory)
         for file in files
             if Base.endswith(file, ".jl") && !(file in ignore_files)
-                include("$path/$file")
-                println("included $path/$file")
                 try
-                    println("function $func_name: $(isdefined(Main, fn))")
-                    if isdefined(Main, fn)
-                        return fn
+                    fn_present = false
+                    open("$path/$file") do f
+                        if contains(read(f, String), "function $func_name")
+                            fn_present = true
+                        end
+                    end
+                    if fn_present
+                        include("$path/$file")
+                        if isdefined(Main, fn)
+                            return fn
+                        end
                     end
                 catch e
                 end

--- a/FaaSr_py/client/julia_func_helper.jl
+++ b/FaaSr_py/client/julia_func_helper.jl
@@ -16,23 +16,26 @@ function faasr_import_function_walk(func_name, directory=".")
     fn = Symbol(func_name)
 
 
+    faasr_log("Starting user function search: $func_name")
     for (path, dirs, files) in Base.Filesystem.walkdir(directory)
         for file in files
             if Base.endswith(file, ".jl") && !(file in ignore_files)
-                try
-                    fn_present = false
-                    open("$path/$file") do f
-                        if contains(read(f, String), "function $func_name")
-                            fn_present = true
-                        end
+                fn_present = false
+                open("$path/$file") do f
+                    if contains(read(f, String), "function $func_name")
+                        fn_present = true
                     end
-                    if fn_present
+                end
+                if fn_present
+                    try
                         include("$path/$file")
-                        if isdefined(Main, fn)
-                            return fn
-                        end
+                    catch e
+                        faasr_log("Error while including user function: $e")
+                        return nothing
                     end
-                catch e
+                    if isdefined(Main, fn)
+                        return fn
+                    end
                 end
             end
         end

--- a/FaaSr_py/client/julia_user_func_entry.jl
+++ b/FaaSr_py/client/julia_user_func_entry.jl
@@ -11,14 +11,12 @@ function run_julia_function(func_name, args, invocationID)
         )
     catch e
         err_msg = string("failed to get the user function", e)
-        println(err_msg)
         faasr_exit(err_msg)
         return
     end
 
     if user_function == nothing
         err_msg = "failed to find user function $func_name"
-        println(err_msg)
         faasr_exit(err_msg)
         return
     end
@@ -30,23 +28,15 @@ function run_julia_function(func_name, args, invocationID)
     try
         arg_array = collect(values(args))
 
-        println("user_function exists: $(isdefined(Main, user_function))")
-        println("user_function type: ", typeof(user_function))
-        println("Is callable: ", applicable(user_function, arg_array...))
-        println("arg_array: ", arg_array)
-        println("arg types: ", typeof.(arg_array))
-            
-        fn_expr = arg_array == [] ? 
-            Expr(:call, user_function) :
-            Expr(:call, user_function, arg_array...)
+        fn_expr = Expr(:call, user_function, arg_array...)
         return_value = eval(fn_expr) 
 
         if return_value != nothing
             result = return_value
         end
+
     catch e
         err_msg = string("Error while running user function: ", e)
-        println(err_msg)
         faasr_exit(err_msg)
     end
 

--- a/FaaSr_py/client/julia_user_func_entry.jl
+++ b/FaaSr_py/client/julia_user_func_entry.jl
@@ -1,0 +1,69 @@
+include("./julia_func_helper.jl")
+include("./julia_client_stubs.jl")
+
+
+function run_julia_function(func_name, args, invocationID)
+
+    user_function = nothing
+    try
+        user_function = faasr_import_function_walk(
+            func_name, "/tmp/functions/$(invocationID)"
+        )
+    catch e
+        err_msg = string("failed to get the user function", e)
+        println(err_msg)
+        faasr_exit(err_msg)
+        return
+    end
+
+    if user_function == nothing
+        err_msg = "failed to find user function $func_name"
+        println(err_msg)
+        faasr_exit(err_msg)
+        return
+    end
+
+
+
+    result = Dict()
+
+    try
+        arg_array = collect(values(args))
+
+        println("user_function exists: $(isdefined(Main, user_function))")
+        println("user_function type: ", typeof(user_function))
+        println("Is callable: ", applicable(user_function, arg_array...))
+        println("arg_array: ", arg_array)
+        println("arg types: ", typeof.(arg_array))
+            
+        fn_expr = arg_array == [] ? 
+            Expr(:call, user_function) :
+            Expr(:call, user_function, arg_array...)
+        return_value = eval(fn_expr) 
+
+        if return_value != nothing
+            result = return_value
+        end
+    catch e
+        err_msg = string("Error while running user function: ", e)
+        println(err_msg)
+        faasr_exit(err_msg)
+    end
+
+    faasr_return(result)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    func_name = ARGS[1]
+    args_raw = ARGS[2]
+    args = JSON.parse(args_raw)
+    invocationID = ARGS[3]
+    run_julia_function(func_name, args, invocationID)
+end
+
+    
+
+
+
+
+

--- a/FaaSr_py/engine/executor.py
+++ b/FaaSr_py/engine/executor.py
@@ -125,7 +125,7 @@ class Executor:
                         ], capture_output=True, text=True
                     )
                 except Exception as e:
-                    logger.error(f"Error running Julia function: {e}")
+                    logger.error(f"Error running Julia function: {julia_func.stdout} {julia_func.stderr}")
                     sys.exit(1)
                 func_res = julia_func.returncode
 
@@ -134,7 +134,6 @@ class Executor:
                 sys.exit(1)
 
             if func_res != 0:
-                logger.error(f"Julia function failed: {julia_func.stdout} {julia_func.stderr}")
                 raise RuntimeError(
                     f"non-zero exit code ({func_res!r}) from user function"
                 )

--- a/FaaSr_py/engine/executor.py
+++ b/FaaSr_py/engine/executor.py
@@ -96,11 +96,45 @@ class Executor:
                     logger.error(f"Error running R function: {e}")
                     sys.exit(1)
                 func_res = r_func.returncode
+            elif func_type == "Julia":
+                # path to Julia function handler
+                client_dir = Path(__file__).parent.parent / "client"
+
+                julia_files = [
+                    client_dir / "julia_user_func_entry.jl",
+                    client_dir / "julia_func_helper.jl",
+                    client_dir / "julia_client_stubs.jl",
+                ]
+
+                # Copy each file into the current working directory
+                for src in julia_files:
+                    dst = Path(src.name)
+                    shutil.copy(src, dst)
+
+                logger.info(f"Starting function: {func_name} (Julia)")
+
+                # run Julia entry as a subprocess
+                try:
+                    julia_func = subprocess.run(
+                        [
+                            "julia",
+                            "julia_user_func_entry.jl",
+                            func_name,
+                            json.dumps(user_args),
+                            self.faasr["InvocationID"],
+                        ], capture_output=True, text=True
+                    )
+                except Exception as e:
+                    logger.error(f"Error running Julia function: {e}")
+                    sys.exit(1)
+                func_res = julia_func.returncode
+
             else:
                 logger.error(f"Unkown function type: {func_type}")
                 sys.exit(1)
 
             if func_res != 0:
+                logger.error(f"Julia function failed: {julia_func.stdout} {julia_func.stderr}")
                 raise RuntimeError(
                     f"non-zero exit code ({func_res!r}) from user function"
                 )

--- a/FaaSr_py/helpers/faasr_start_invoke_helper.py
+++ b/FaaSr_py/helpers/faasr_start_invoke_helper.py
@@ -286,6 +286,34 @@ def faasr_install_cran(package, lib_path=None):
     else:
         logger.info(f"Successfully installed {package}")
 
+def faasr_install_pkg(package):
+    """
+    Installs a single Pkg package non-interactively
+    """
+    if not package:
+        logger.info("No Pkg package dependency")
+        return
+
+    logger.info(f"Installing Pkg package: {package}")
+
+    command = [
+        "julia",
+        "-e",
+        f'using Pkg; Pkg.add(["{package}"]) '
+    ]
+
+    result = subprocess.run(command, text=True, capture_output=True)
+
+    if result.returncode != 0:
+        logger.error(
+            f"Failed to install {package}:\n"
+            f"std err: {result.stderr}\n"
+            f"std out: {result.stdout}"
+        )
+        raise RuntimeError(f"Install failed for {package}")
+    else:
+        logger.info(f"Successfully installed {package}")
+
 
 def faasr_pip_gh_install(path):
     """
@@ -424,6 +452,17 @@ def faasr_func_dependancy_install(faasr_source, action):
 
         logger.debug(f"Packages in /tmp/Rlibs: {os.listdir('/tmp/Rlibs')}")
 
+    elif "JuliaPkgPackage" in faasr_source and func_type == "Julia":
+        lib_path = "/tmp/julia_depot"
+        if "JuliaPkgPackage" in faasr_source:
+            pkg_packages = faasr_source["JuliaPkgPackage"].get(func_name)
+
+        if pkg_packages:
+            for package in pkg_packages:
+                faasr_install_pkg(package)
+
+        pkg_list = os.listdir(f'{lib_path}/packages')
+        logger.debug(f"Packages in {lib_path}/packages: {pkg_list}")
     # install gh packages
     if "FunctionGitHubPackage" in faasr_source:
         if func_name in faasr_source["FunctionGitHubPackage"]:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include FaaSr_py/config/config.json
 include FaaSr_py/FaaSr.schema.json
 include requirements.txt
-recursive-include FaaSr_py *.R
+recursive-include FaaSr_py *.R *.jl


### PR DESCRIPTION
This pull request implements Julia as a type in the FaaSr schema, and supports calling the Julia function runner to execute any action with that type. FaaSr functions are also exposed via a Julia RPC client (client/julia_client_stubs.jl).

It also adds support for Julia package installation via Pkg. Packages can be specified for each function with the JuliaPkgPackage field in the workflow JSON.