### PR TITLE
Initial Kubernetes deployment changes

### DIFF
--- a/FaaSr_py/FaaSr.schema.json
+++ b/FaaSr_py/FaaSr.schema.json
@@ -218,7 +218,8 @@
                 "GitHubActions",
                 "Lambda",
                 "GoogleCloud",
-                "SLURM"
+                "SLURM",
+                "Kubernetes"
               ]
             },
             "Region": {
@@ -429,6 +430,23 @@
                   "UserName",
                   "APIVersion",
                   "Partition"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "FaaSType": {
+                    "const": "Kubernetes"
+                  }
+                },
+                "required": [
+                  "FaaSType"
+                ]
+              },
+              "then": {
+                "required": [
+                  "Endpoint"
                 ]
               }
             }

--- a/FaaSr_py/FaaSr.schema.json
+++ b/FaaSr_py/FaaSr.schema.json
@@ -336,6 +336,18 @@
               "type": "number",
               "minimum": 1,
               "description": "Maximum storage for server-level default in MB"
+            },
+            "CPULimit": {
+              "type": "string",
+              "description": "The maximum amount of CPU usage allowed for a specific container on the Kubernetes cluster, specified in millicores"
+            },
+            "MemoryLimit": {
+              "type": "string",
+              "description": "The maximum amount of memory usage allowed for a specific container on the Kubernetes cluster, specified in memory units (ie. GiB, MiB, GB, MB, etc.)"
+            },
+            "SSLCertificate": {
+              "type": "string",
+              "description": "The SSL certificate specified to authorize a domain with the SSL authority certificate"
             }
           },
           "additionalProperties": false,

--- a/FaaSr_py/FaaSr.schema.json
+++ b/FaaSr_py/FaaSr.schema.json
@@ -337,17 +337,22 @@
               "minimum": 1,
               "description": "Maximum storage for server-level default in MB"
             },
-            "CPULimit": {
-              "type": "string",
+            "MaxCPU": {
+              "type": "number",
+              "minimum": 1,
               "description": "The maximum amount of CPU usage allowed for a specific container on the Kubernetes cluster, specified in millicores"
-            },
-            "MemoryLimit": {
-              "type": "string",
-              "description": "The maximum amount of memory usage allowed for a specific container on the Kubernetes cluster, specified in memory units (ie. GiB, MiB, GB, MB, etc.)"
             },
             "SSLCertificate": {
               "type": "string",
               "description": "The SSL certificate specified to authorize a domain with the SSL authority certificate"
+            },
+            "AdditionalTimeToLive": {
+              "type": "number",
+              "minimum": 1
+            },
+            "NumberOfRetries": {
+              "type": "number",
+              "minimum": 0
             }
           },
           "additionalProperties": false,

--- a/FaaSr_py/engine/faasr_payload.py
+++ b/FaaSr_py/engine/faasr_payload.py
@@ -134,6 +134,8 @@ class FaaSrPayload:
             GCP_SecretKey
         SLURM
             SLURM_Token
+        Kubernetes
+            K8s_Token
         GH
             GH_PAT
         Minio
@@ -178,6 +180,10 @@ class FaaSrPayload:
                 case "OpenWhisk":
                     api_key = _get(f"{name}_APIkey")
                     self._base_workflow["ComputeServers"][name]["APIkey"] = api_key
+
+                case "Kubernetes":
+                    token = _get(f"{name}_Token")
+                    self._base_workflow["ComputeServers"][name]["Token"] = token
 
                 case _:
                     logger.warning(f"Unknown FaaSType for {name}: {faas_type}")

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -697,11 +697,7 @@ class Scheduler:
         numberOfRetries = server_info.get("NumberOfRetries")
 
         allowSelfSignedCertificate = server_info.get("AllowSelfSignedCertificate")
-
-        certificate = None
-
-        if (allowSelfSignedCertificate):
-            certificate = server_info.get("SSLCertificate") #This is default behavior, but the certificate is completely optional
+        certificate = server_info.get("SSLCertificate")
 
         resourceObject = {}
 
@@ -822,7 +818,8 @@ class Scheduler:
                 headers=None,
                 body=job_payload,
                 token=token,
-                certificate=certificate
+                certificate=certificate,
+                selfSigned=allowSelfSignedCertificate
             )
 
             if response.status_code in [200, 201, 202]:

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -771,7 +771,7 @@ class Scheduler:
 
         gh_pat = os.getenv("GH_PAT")
         if gh_pat:
-            environment_vars += {"name": "GH_PAT", "value": gh_pat}
+            environment_vars.append({"name": "GH_PAT", "value": gh_pat})
 
         action_containers = self.faasr.base_workflow["ActionContainers"]
         if not action_containers.get(original_function):

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -771,7 +771,7 @@ class Scheduler:
 
         gh_pat = os.getenv("GH_PAT")
         if gh_pat:
-            environment_vars["GH_PAT"] = gh_pat
+            environment_vars += {"name": "GH_PAT", "value": gh_pat}
 
         action_containers = self.faasr.base_workflow["ActionContainers"]
         if not action_containers.get(original_function):

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -700,8 +700,6 @@ class Scheduler:
         allowSelfSignedCertificate = server_info.get("AllowSelfSignedCertificate")
         certificate = server_info.get("SSLCertificate")
 
-        invocationTimestamp = overwritten_fields["InvocationTimestamp"]
-
         resourceObject = {}
         if (memoryLimit and cpuLimit):
             resourceObject = {
@@ -781,6 +779,7 @@ class Scheduler:
             sys.exit(1)
         
         container = action_containers[original_function]
+        invocationTimestamp = overwritten_fields["InvocationTimestamp"]
 
         # Create the job payload
         job_payload = {

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+import uuid
 
 import boto3
 import requests
@@ -781,11 +782,12 @@ class Scheduler:
         container = action_containers[original_function]
 
         # Create the job payload
+        unique_data = uuid.uuid4()
         job_payload = {
             "apiVersion": "batch/v1",
             "kind": "Job",
             "metadata": {
-                "name": f"{function}"
+                "name": f"{function}-{unique_data}"
             },
             "spec": {
                 "activeDeadlineSeconds": activeDeadlineSeconds,

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -708,11 +708,11 @@ class Scheduler:
         if (memoryLimit and cpuLimit):
             resourceObject = {
                     "requests": {
-                        "memory": f"{memoryLimit}MB",
+                        "memory": f"{memoryLimit}M",
                         "cpu": f"{cpuLimit}m"
                     },
                     "limits": {
-                        "memory": f"{memoryLimit}MB",
+                        "memory": f"{memoryLimit}M",
                         "cpu": f"{cpuLimit}m"
                     }
                 }

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -690,21 +690,30 @@ class Scheduler:
         server_info = next_compute_server
         endpoint = server_info["Endpoint"]
         namespace = server_info.get("Namespace", "default")
-        certificate = server_info.get("SSLCertificate") #This is default behavior, but the certificate is completely optional
-        memoryLimit = server_info.get("MemoryLimit")
-        cpuLimit = server_info.get("CPULimit")
+        memoryLimit = server_info.get("MaxMemory")
+        cpuLimit = server_info.get("MaxCPU")
+        activeDeadlineSeconds = server_info.get("TimeLimit")
+        additionalTTL = server_info.get("AdditionalTimeToLive")
+        numberOfRetries = server_info.get("NumberOfRetries")
+
+        allowSelfSignedCertificate = server_info.get("AllowSelfSignedCertificate")
+
+        certificate = None
+
+        if (allowSelfSignedCertificate):
+            certificate = server_info.get("SSLCertificate") #This is default behavior, but the certificate is completely optional
 
         resourceObject = {}
 
         if (memoryLimit and cpuLimit):
             resourceObject = {
                     "requests": {
-                        "memory": f"{memoryLimit}",
-                        "cpu": f"{cpuLimit}"
+                        "memory": f"{memoryLimit}MB",
+                        "cpu": f"{cpuLimit}m"
                     },
                     "limits": {
-                        "memory": f"{memoryLimit}",
-                        "cpu": f"{cpuLimit}"
+                        "memory": f"{memoryLimit}MB",
+                        "cpu": f"{cpuLimit}m"
                     }
                 }
 
@@ -779,7 +788,7 @@ class Scheduler:
                 "name": f"{function}"
             },
             "spec": {
-                "activeDeadlineSeconds": 300,
+                "activeDeadlineSeconds": activeDeadlineSeconds,
                 "template": {
                     "spec": {
                         "containers": [
@@ -793,8 +802,8 @@ class Scheduler:
                         "restartPolicy": "Never"
                     }
                 },
-                "backoffLimit": 4,
-                "ttlSecondsAfterFinished": 10
+                "backoffLimit": numberOfRetries,
+                "ttlSecondsAfterFinished": additionalTTL
             }
         }
 

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -691,6 +691,23 @@ class Scheduler:
         endpoint = server_info["Endpoint"]
         namespace = server_info.get("Namespace", "default")
         certificate = server_info.get("SSLCertificate") #This is default behavior, but the certificate is completely optional
+        memoryLimit = server_info.get("MemoryLimit")
+        cpuLimit = server_info.get("CPULimit")
+
+        resourceObject = {}
+
+        if (memoryLimit and cpuLimit):
+            resourceObject = {
+                    "requests": {
+                        "memory": f"{memoryLimit}",
+                        "cpu": f"{cpuLimit}"
+                    },
+                    "limits": {
+                        "memory": f"{memoryLimit}",
+                        "cpu": f"{cpuLimit}"
+                    }
+                }
+
 
         #Ensure endpoint is formatted correctly
         if not endpoint.startswith("http"):
@@ -766,7 +783,8 @@ class Scheduler:
                             {
                                 "name": f"{function}",
                                 "image": f"{container}",
-                                "env": environment_vars
+                                "env": environment_vars,
+                                "resources": resourceObject
                             }
                         ],
                         "restartPolicy": "Never"

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -700,8 +700,9 @@ class Scheduler:
         allowSelfSignedCertificate = server_info.get("AllowSelfSignedCertificate")
         certificate = server_info.get("SSLCertificate")
 
-        resourceObject = {}
+        invocationTimestamp = overwritten_fields["InvocationTimestamp"]
 
+        resourceObject = {}
         if (memoryLimit and cpuLimit):
             resourceObject = {
                     "requests": {
@@ -786,7 +787,10 @@ class Scheduler:
             "apiVersion": "batch/v1",
             "kind": "Job",
             "metadata": {
-                "generateName": f"{function}-"
+                "generateName": f"{function}-",
+                "labels": {
+                    "InvocationTimestamp": invocationTimestamp
+                }
             },
             "spec": {
                 "activeDeadlineSeconds": activeDeadlineSeconds,

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -773,6 +773,10 @@ class Scheduler:
             {"name": "OVERWRITTEN", "value": json.dumps(overwritten_fields, separators=(",", ":"))}
         ]
 
+        gh_pat = os.getenv("GH_PAT")
+        if gh_pat:
+            environment_vars["GH_PAT"] = gh_pat
+
         action_containers = self.faasr.base_workflow["ActionContainers"]
         if not action_containers.get(original_function):
             logger.error(f"Unable to get a valid container associated with the function: {original_function}")

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -787,7 +787,7 @@ class Scheduler:
             "apiVersion": "batch/v1",
             "kind": "Job",
             "metadata": {
-                "name": f"{function}-{unique_data}"
+                "name": f"{function}-{unique_data[:8]}"
             },
             "spec": {
                 "activeDeadlineSeconds": activeDeadlineSeconds,

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -738,7 +738,10 @@ class Scheduler:
             if (not isValid):
                 sys.exit(1)
             elif (hasChanged):
-                overwritten_fields["ComputeServers"][next_server]["SSLCertificate"] = certificate
+                if "ComputeServers" in overwritten_fields:
+                    overwritten_fields["ComputeServers"][next_server]["SSLCertificate"] = certificate
+                else:
+                    overwritten_fields["ComputeServers"] = {f"{next_server}": {"SSLCertificate": f"{certificate}"}}
 
         if next_compute_server.get("UseSecretStore"):
             if "ComputeServers" in overwritten_fields:

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -113,6 +113,8 @@ class Scheduler:
                         self.invoke_googlecloud(
                             next_compute_server, function, workflow_name
                         )
+                    case "Kubernetes":
+                        self.invoke_kubernetes(next_compute_server, function, workflow_name)
 
             else:
                 msg = f"SIMULATED TRIGGER: {function}"
@@ -661,6 +663,166 @@ class Scheduler:
         except Exception as e:
             logger.exception(f"GoogleCloud: Request failed: {e}")
             sys.exit(1)
+
+
+    def invoke_kubernetes(self, next_compute_server, function, workflow_name=None):
+        """
+        Deploy the next job to a Kubernetes cluster
+        
+        Arguments:
+            next_compute_server: dict -- next compute server configuration
+            function: str -- name of the function to invoke
+        """
+
+        from FaaSr_py.helpers.kubernetes_helper import (
+            make_kubernetes_request,
+            validate_jwt_token
+        )
+
+        original_function = function
+
+        if workflow_name:
+            function = f"{workflow_name}-{function}"
+            logger.debug(f"Prepending workflow name. Full function: {function}")
+
+        # Get server configuration
+        server_info = next_compute_server
+        endpoint = server_info["Endpoint"]
+        namespace = server_info.get("Namespace", "default")
+
+        #Ensure endpoint is formatted correctly
+        if not endpoint.startswith("http"):
+            endpoint = f"https://{endpoint}"
+        
+        token = server_info.get("Token")
+        if not token or token.strip() == "":
+            err_msg = f"K8s: No authentication token available for server {function}"
+            logger.error(err_msg)
+            sys.exit(1)
+
+        #Validate JWT token
+        token_validation = validate_jwt_token(token)
+        if not token_validation["valid"]:
+            err_msg = (
+                f"K8s: Token validation failed for {self.faasr['FunctionInvoke']} - "
+                f"{token_validation['error']}"
+            )
+            logger.error(err_msg)
+            sys.exit(1)
+
+        # Create overwritten fields for next action
+        overwritten_fields = self.faasr.overwritten.copy()
+
+        if next_compute_server.get("UseSecretStore"):
+            if "ComputerServers" in overwritten_fields:
+                del overwritten_fields["ComputeServers"]
+            if "DataStores" in overwritten_fields:
+                del overwritten_fields["DataStores"]
+            logger.info(
+                "Next Kubernetes action will use secret store. Secrets not included in payload"
+            )
+        else:
+            overwritten_fields["ComputeServers"] = self.faasr["ComputeServers"]
+            overwritten_fields["DataStores"] = self.faasr["DataStores"]
+            logger.info(
+                "Next Kubernetes action expects secrets in payload - including credentials"
+            )
+    
+        # Prepare environment variables
+        environment_vars = [
+            {"name": "PAYLOAD_URL", "value": self.faasr.url},
+            {"name": "OVERWRITTEN", "value": json.dumps(overwritten_fields, separators=(",", ":"))}
+        ]
+
+        action_containers = self.faasr.base_workflow["ActionContainers"]
+        if not action_containers.get(original_function):
+            logger.error(f"Unable to get a valid container associated with the function: {original_function}")
+            sys.exit(1)
+        
+        container = action_containers[original_function]
+
+        # Create the job payload
+        job_payload = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": f"{function}"
+            },
+            "spec": {
+                "activeDeadlineSeconds": 300,
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": f"{function}",
+                                "image": f"{container}",
+                                "env": environment_vars
+                            }
+                        ],
+                        "restartPolicy": "Never"
+                    }
+                },
+                "backoffLimit": 4,
+                "ttlSecondsAfterFinished": 10
+            }
+        }
+
+        submit_url = f"{endpoint}/apis/batch/v1/namespaces/{namespace}/jobs"
+
+        logger.info(f"Kubernetes: submitting job to {submit_url}")
+ 
+        try:
+            response = make_kubernetes_request(
+                endpoint=submit_url,
+                method="POST",
+                headers=None,
+                body=job_payload,
+                token=token
+            )
+
+            if response.status_code in [200, 201, 202]:
+                job_info = response.json()
+
+                uid = "Unknown"
+                creationTimestamp = 0
+
+                metadata = job_info["metadata"]
+
+                if (metadata.get("uid")):
+                    uid = metadata["uid"]
+
+                if (metadata.get("creationTimestamp")):
+                    creationTimestamp = metadata["creationTimestamp"]
+
+                succ_msg = (
+                    f"Kubernetes: Successfully submitted jobs: {self.faasr['FunctionInvoke']} "
+                    f"(Job ID: {uid})",
+                    f"(Created at: {creationTimestamp})"
+                )
+                logger.info(succ_msg)
+            else:
+                error_content = response.text
+                err_msg = (
+                    f"Kubernetes: Error submitting job: {self.faasr['FunctionInvoke']} - "
+                    f"HTTP {response.status_code}: {error_content}"
+                )
+                logger.error(err_msg)
+
+                if response.status_code == 401:
+                    logger.error(
+                        "Kubernetes: Authentication failed - check token validity and username"
+                    )
+                elif response.status_code == 403:
+                    logger.error(
+                        "Kubernetes: Authorization failed - check user permissions"
+                    )
+                
+                sys.exit(1)
+        
+        except Exception as e:
+            logger.exception(f"Kubernetes request failed: {e}")
+            sys.exit(1)
+
 
 
 def contains_dict(list_obj):

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -114,7 +114,7 @@ class Scheduler:
                             next_compute_server, function, workflow_name
                         )
                     case "Kubernetes":
-                        self.invoke_kubernetes(next_compute_server, function, workflow_name)
+                        self.invoke_kubernetes(next_server, next_compute_server, function, workflow_name)
 
             else:
                 msg = f"SIMULATED TRIGGER: {function}"
@@ -665,7 +665,7 @@ class Scheduler:
             sys.exit(1)
 
 
-    def invoke_kubernetes(self, next_compute_server, function, workflow_name=None):
+    def invoke_kubernetes(self, next_server, next_compute_server, function, workflow_name=None):
         """
         Deploy the next job to a Kubernetes cluster
         
@@ -676,7 +676,8 @@ class Scheduler:
 
         from FaaSr_py.helpers.kubernetes_helper import (
             make_kubernetes_request,
-            validate_jwt_token
+            validate_jwt_token,
+            validate_certificate
         )
 
         original_function = function
@@ -689,6 +690,7 @@ class Scheduler:
         server_info = next_compute_server
         endpoint = server_info["Endpoint"]
         namespace = server_info.get("Namespace", "default")
+        certificate = server_info.get("SSLCertificate") #This is default behavior, but the certificate is completely optional
 
         #Ensure endpoint is formatted correctly
         if not endpoint.startswith("http"):
@@ -713,8 +715,16 @@ class Scheduler:
         # Create overwritten fields for next action
         overwritten_fields = self.faasr.overwritten.copy()
 
+        if (certificate != None):
+            (isValid, hasChanged, certificate) = validate_certificate(certificate)
+            # If the register workflow was run, this is already valid, but to check
+            if (not isValid):
+                sys.exit(1)
+            elif (hasChanged):
+                overwritten_fields["ComputeServers"][next_server]["SSLCertificate"] = certificate
+
         if next_compute_server.get("UseSecretStore"):
-            if "ComputerServers" in overwritten_fields:
+            if "ComputeServers" in overwritten_fields:
                 del overwritten_fields["ComputeServers"]
             if "DataStores" in overwritten_fields:
                 del overwritten_fields["DataStores"]
@@ -777,7 +787,8 @@ class Scheduler:
                 method="POST",
                 headers=None,
                 body=job_payload,
-                token=token
+                token=token,
+                certificate=certificate
             )
 
             if response.status_code in [200, 201, 202]:

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -782,12 +782,11 @@ class Scheduler:
         container = action_containers[original_function]
 
         # Create the job payload
-        unique_data = f"{uuid.uuid4()}"
         job_payload = {
             "apiVersion": "batch/v1",
             "kind": "Job",
             "metadata": {
-                "name": f"{function}-{unique_data[:8]}"
+                "generateName": f"{function}-"
             },
             "spec": {
                 "activeDeadlineSeconds": activeDeadlineSeconds,

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -782,7 +782,7 @@ class Scheduler:
         container = action_containers[original_function]
 
         # Create the job payload
-        unique_data = uuid.uuid4()
+        unique_data = f"{uuid.uuid4()}"
         job_payload = {
             "apiVersion": "batch/v1",
             "kind": "Job",

--- a/FaaSr_py/engine/scheduler.py
+++ b/FaaSr_py/engine/scheduler.py
@@ -781,6 +781,33 @@ class Scheduler:
         container = action_containers[original_function]
         invocationTimestamp = overwritten_fields["InvocationTimestamp"]
 
+
+
+        specDictionary = {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": f"{function}",
+                            "image": f"{container}",
+                            "env": environment_vars,
+                        }
+                    ],
+                    "restartPolicy": "Never"
+                }
+            },
+            "backoffLimit": (numberOfRetries if numberOfRetries is not None else 6),
+        }
+
+        if (activeDeadlineSeconds is not None):
+            specDictionary["activeDeadlineSeconds"] = activeDeadlineSeconds
+        
+        if (additionalTTL is not None):
+            specDictionary["ttlSecondsAfterFinished"] = additionalTTL
+
+        if (resourceObject):
+            specDictionary["template"]["spec"]["containers"][0]["resources"] = resourceObject
+
         # Create the job payload
         job_payload = {
             "apiVersion": "batch/v1",
@@ -791,24 +818,7 @@ class Scheduler:
                     "InvocationTimestamp": invocationTimestamp
                 }
             },
-            "spec": {
-                "activeDeadlineSeconds": activeDeadlineSeconds,
-                "template": {
-                    "spec": {
-                        "containers": [
-                            {
-                                "name": f"{function}",
-                                "image": f"{container}",
-                                "env": environment_vars,
-                                "resources": resourceObject
-                            }
-                        ],
-                        "restartPolicy": "Never"
-                    }
-                },
-                "backoffLimit": numberOfRetries,
-                "ttlSecondsAfterFinished": additionalTTL
-            }
+            "spec": specDictionary
         }
 
         submit_url = f"{endpoint}/apis/batch/v1/namespaces/{namespace}/jobs"

--- a/FaaSr_py/helpers/kubernetes_helper.py
+++ b/FaaSr_py/helpers/kubernetes_helper.py
@@ -1,0 +1,101 @@
+import base64
+import json
+import logging
+import time
+from datetime import datetime
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+def validate_jwt_token(token):
+    """
+    Validates JWT tokens for Kubernetes authentication
+    Checks token format and decodes the payload
+    
+    Arguments:
+        token: str -- JWT token string to validate
+    Returns:
+        dict: {"valid": bool, "error": str}
+    """
+
+    if not token or not token.startswith("eyJ"):
+        return {"valid": False, "error": "Invalid token format"}
+    
+    try:
+        # Decode the payload
+        parts = token.split(".")
+        if len(parts) < 2:
+            return {"valid": False, "error": "JWT is malformed"}
+        
+        payload = parts[1]
+        # Add padding
+        padding = 4 - (len(payload) % 4)
+        if padding != 4:
+            payload += "=" * padding
+        
+        # Decode base64
+        decoded_bytes = base64.b64decode(payload)
+        decoded_json = decoded_bytes.decode("utf-8")
+        payload_data = json.loads(decoded_json)
+
+        if (not payload_data.get("iss") or payload_data["iss"] != "kubernetes/serviceaccount" or not payload_data.get("kubernetes.io/serviceaccount/namespace") or not payload_data.get("kubernetes.io/serviceaccount/secret.name")):
+            return {"valid": False, "error": "Invalid Kubernetes secret format"}
+        
+        return {"valid": True, "error": None}
+    
+    except Exception as e:
+        return {"valid": False, "error": "Unable to decode the JWT token payload"}
+    
+
+def make_kubernetes_request(
+    endpoint, method="GET", headers=None, body=None, token=None, username=None
+):
+    """
+    Helper function to send HTTPS requests to the Kubernetes REST API
+    
+    Arguments:
+        endpoint: str -- full URL endpoint
+        method: str -- HTTP method
+        headers: dict -- HTTP headers
+        body: dict -- request body (optional)
+        token: str -- JWT token from server configuration
+        username: str -- username from server configuration
+    Returns:
+        requests.Response: HTTP response
+    """
+
+    if headers is None:
+        headers = {}
+    
+    if not token or not token.strip():
+        logger.error(
+            "Kubernetes token is required - server will close connection without authentication"
+        )
+        raise ValueError("Kubernetes token is required for authentication")
+    
+    token = token.strip()
+    if not token.startswith("eyJ"):
+        logger.error(
+            f"Token doesn't look like JWT (it should start with 'eyJ'): {token[:10]}..."
+        )
+        raise ValueError("Invalid JWT token format")
+    
+    headers["Authorization"] = f"Bearer {token}"
+    headers["Accept"] = "application/json"
+
+    if (method.upper() == "POST"):
+        headers["Content-Type"] = "application/json"
+
+    if (method.upper() == "GET"):
+        response = requests.get(url=endpoint, headers=headers, timeout=30)
+    elif (method.upper() == "POST"):
+        response = requests.post(url=endpoint, headers=headers, json=body, timeout=30, verify=False)
+    elif (method.upper() == "PUT"):
+        response = requests.put(url=endpoint, headers=headers, json=body, timeout=30)
+    elif (method.upper() == "DELETE"):
+        response = requests.delete(url=endpoint, headers=headers, timeout=30)
+    else:
+        raise ValueError(f"Unsupported HTTP method: {method}")
+    
+    return response

--- a/FaaSr_py/helpers/kubernetes_helper.py
+++ b/FaaSr_py/helpers/kubernetes_helper.py
@@ -35,12 +35,32 @@ def validate_jwt_token(token):
         if padding != 4:
             payload += "=" * padding
         
-        # Decode base64
-        decoded_bytes = base64.b64decode(payload)
-        decoded_json = decoded_bytes.decode("utf-8")
-        payload_data = json.loads(decoded_json)
 
-        if (not payload_data.get("iss") or payload_data["iss"] != "kubernetes/serviceaccount" or not payload_data.get("kubernetes.io/serviceaccount/namespace") or not payload_data.get("kubernetes.io/serviceaccount/secret.name")):
+        try:
+            decoded_bytes = base64.b64decode(payload)
+            decoded_json = decoded_bytes.decode("utf-8")
+            payload_data = json.loads(decoded_json)
+        except (ValueError, UnicodeDecodeError) as e:
+            return {"valid": False, "error": f"Unable to decode and parse the JWT token: {e}"}
+
+        # This is the new service account format
+        if (payload_data.get("exp") and payload_data.get("kubernetes.io") and payload_data.get("iat")):
+            if (payload_data.get("exp") < int(time.time())):
+                return {"valid": False, "error": f"The temporary JWT token is expired!\n"}
+            elif (payload_data.get("iat") > int(time.time())):
+                return {"valid": False, "error": f"The JWT is malformed!\n"}
+            else:
+                kubernetes_info = payload_data["kubernetes.io"]
+
+                if (not kubernetes_info.get("namespace") or not kubernetes_info.get("serviceaccount")):
+                    return {"valid": False, "error": f"The Kubernetes section of the JWT is malformed!\n"}
+
+        # Both tokens must have an issuer - if its not included, assume this is not valid token
+        elif (payload_data.get("iss") and payload_data.get("kubernetes.io/serviceaccount/namespace") and payload_data.get("kubernetes.io/serviceaccount/secret.name")):
+            if (payload_data["iss"] != "kubernetes/serviceaccount"):
+                return {"valid": False, "error": f"The service account is incorrectly configured!\n"}
+              
+        else:
             return {"valid": False, "error": "Invalid Kubernetes secret format"}
         
         return {"valid": True, "error": None}

--- a/FaaSr_py/helpers/kubernetes_helper.py
+++ b/FaaSr_py/helpers/kubernetes_helper.py
@@ -4,10 +4,24 @@ import logging
 import time
 from datetime import datetime
 import os
+import ssl
+from requests.adapters import HTTPAdapter
 
 import requests
 
 logger = logging.getLogger(__name__)
+
+class LaxSSLAdapter(HTTPAdapter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        # Pass the custom context to urllib3's PoolManager
+        ctx = ssl.create_default_context()
+        ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+
+        pool_kwargs['ssl_context'] = ctx
+        return super().init_poolmanager(connections, maxsize, block, **pool_kwargs)
 
 def validate_jwt_token(token):
     """
@@ -70,7 +84,7 @@ def validate_jwt_token(token):
     
 
 def make_kubernetes_request(
-    endpoint, method="GET", headers=None, body=None, token=None, certificate=None, username=None
+    endpoint, method="GET", headers=None, body=None, token=None, certificate=None, selfSigned=False
 ):
     """
     Helper function to send HTTPS requests to the Kubernetes REST API
@@ -113,6 +127,10 @@ def make_kubernetes_request(
 
     request_session = requests.Session()
     
+    if (selfSigned):
+        adapter = LaxSSLAdapter()
+        request_session.mount("https://", adapter)
+
     if (certificate):
         with open("./temp.pem", "w") as certFile:
             certFile.write(certificate)

--- a/FaaSr_py/helpers/kubernetes_helper.py
+++ b/FaaSr_py/helpers/kubernetes_helper.py
@@ -3,6 +3,7 @@ import json
 import logging
 import time
 from datetime import datetime
+import os
 
 import requests
 
@@ -61,6 +62,7 @@ def make_kubernetes_request(
         body: dict -- request body (optional)
         token: str -- JWT token from server configuration
         username: str -- username from server configuration
+        certificate: str -- The certificate data of the authority certificate needed to perform the SSL handshake
     Returns:
         requests.Response: HTTP response
     """
@@ -92,7 +94,12 @@ def make_kubernetes_request(
     request_session = requests.Session()
     
     if (certificate):
-        request_session.verify = certificate
+        with open("./temp.pem", "w") as certFile:
+            certFile.write(certificate)
+        
+        request_session.verify = "./temp.pem"
+
+    logger.info(f"This is the verification information: {request_session.verify}")
 
     if (method.upper() == "GET"):
         response = request_session.get(url=endpoint, headers=headers, timeout=30)
@@ -103,8 +110,13 @@ def make_kubernetes_request(
     elif (method.upper() == "DELETE"):
         response = request_session.delete(url=endpoint, headers=headers, timeout=30)
     else:
+        if (certificate):
+            os.remove("./temp.pem")
         raise ValueError(f"Unsupported HTTP method: {method}")
-    
+
+    if (certificate):
+        os.remove("./temp.pem")
+
     return response
 
 

--- a/FaaSr_py/helpers/kubernetes_helper.py
+++ b/FaaSr_py/helpers/kubernetes_helper.py
@@ -49,7 +49,7 @@ def validate_jwt_token(token):
     
 
 def make_kubernetes_request(
-    endpoint, method="GET", headers=None, body=None, token=None, username=None
+    endpoint, method="GET", headers=None, body=None, token=None, certificate=None, username=None
 ):
     """
     Helper function to send HTTPS requests to the Kubernetes REST API
@@ -87,15 +87,47 @@ def make_kubernetes_request(
     if (method.upper() == "POST"):
         headers["Content-Type"] = "application/json"
 
+    # If the certificate is specified, include it
+
+    request_session = requests.Session()
+    
+    if (certificate):
+        request_session.verify = certificate
+
     if (method.upper() == "GET"):
-        response = requests.get(url=endpoint, headers=headers, timeout=30)
+        response = request_session.get(url=endpoint, headers=headers, timeout=30)
     elif (method.upper() == "POST"):
-        response = requests.post(url=endpoint, headers=headers, json=body, timeout=30, verify=False)
+        response = request_session.post(url=endpoint, headers=headers, json=body, timeout=30)
     elif (method.upper() == "PUT"):
-        response = requests.put(url=endpoint, headers=headers, json=body, timeout=30)
+        response = request_session.put(url=endpoint, headers=headers, json=body, timeout=30)
     elif (method.upper() == "DELETE"):
-        response = requests.delete(url=endpoint, headers=headers, timeout=30)
+        response = request_session.delete(url=endpoint, headers=headers, timeout=30)
     else:
         raise ValueError(f"Unsupported HTTP method: {method}")
     
     return response
+
+
+
+def validate_certificate(certificate):
+    """
+    Test that the certificate is in the correct format, and if it is base64 encoded, decode it to the proper format 
+
+    Args:
+        certificate: The string representing the certificate from the workflow
+
+    Returns:
+        bool: Determines whether the operation was successful or not
+        bool: Determines whether the certificate should be updated in the FaaSrPayload. Ideally, if the certificate is b64 encoded, it is only decoded once, and then just used by every subsequent call
+        string: The validated, or decoded certificate
+    """
+
+    if ("-----BEGIN CERTIFICATE-----" in certificate and "-----END CERTIFICATE-----" in certificate):
+        return (True, False, certificate)
+
+    else:
+        certificate = base64.b64decode(certificate).decode('utf-8')
+        if (certificate and "-----BEGIN CERTIFICATE-----" in certificate and "-----END CERTIFICATE-----" in certificate):
+           return (True, True, certificate)
+
+    return (False, False, None) 

--- a/FaaSr_py/helpers/kubernetes_helper.py
+++ b/FaaSr_py/helpers/kubernetes_helper.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import os
 import ssl
 from requests.adapters import HTTPAdapter
+import uuid
 
 import requests
 
@@ -131,29 +132,31 @@ def make_kubernetes_request(
         adapter = LaxSSLAdapter()
         request_session.mount("https://", adapter)
 
+    temp_cert_identifier = uuid.uuid4()
+
     if (certificate):
-        with open("./temp.pem", "w") as certFile:
+        with open(f"./temp-{temp_cert_identifier}.pem", "w") as certFile:
             certFile.write(certificate)
         
-        request_session.verify = "./temp.pem"
+        request_session.verify = f"./temp-{temp_cert_identifier}.pem"
 
-    logger.info(f"This is the verification information: {request_session.verify}")
-
-    if (method.upper() == "GET"):
-        response = request_session.get(url=endpoint, headers=headers, timeout=30)
-    elif (method.upper() == "POST"):
-        response = request_session.post(url=endpoint, headers=headers, json=body, timeout=30)
-    elif (method.upper() == "PUT"):
-        response = request_session.put(url=endpoint, headers=headers, json=body, timeout=30)
-    elif (method.upper() == "DELETE"):
-        response = request_session.delete(url=endpoint, headers=headers, timeout=30)
-    else:
+    try:
+        if (method.upper() == "GET"):
+            response = request_session.get(url=endpoint, headers=headers, timeout=30)
+        elif (method.upper() == "POST"):
+            response = request_session.post(url=endpoint, headers=headers, json=body, timeout=30)
+        elif (method.upper() == "PUT"):
+            response = request_session.put(url=endpoint, headers=headers, json=body, timeout=30)
+        elif (method.upper() == "DELETE"):
+            response = request_session.delete(url=endpoint, headers=headers, timeout=30)
+        else:
+            raise ValueError(f"Unsupported HTTP method: {method}")        
+    finally:
         if (certificate):
-            os.remove("./temp.pem")
-        raise ValueError(f"Unsupported HTTP method: {method}")
-
-    if (certificate):
-        os.remove("./temp.pem")
+            try:
+                os.remove(f"./temp-{temp_cert_identifier}.pem")
+            except OSError:
+                pass
 
     return response
 

--- a/FaaSr_py/s3_api/log.py
+++ b/FaaSr_py/s3_api/log.py
@@ -75,6 +75,8 @@ def faasr_log(faasr_payload, log_message):
         with open(log_download_path, "a") as f:
             f.write(logs)
 
+        logger.info(f"This is the payload, just to confirm it exists: {faasr_payload}")
+
         # Upload log back to S3
         try:
             with open(log_download_path, "rb") as log_data:

--- a/FaaSr_py/s3_api/log.py
+++ b/FaaSr_py/s3_api/log.py
@@ -75,8 +75,6 @@ def faasr_log(faasr_payload, log_message):
         with open(log_download_path, "a") as f:
             f.write(logs)
 
-        logger.info(f"This is the info: {faasr_payload["DataStores"]}")
-
         # Upload log back to S3
         try:
             with open(log_download_path, "rb") as log_data:

--- a/FaaSr_py/s3_api/log.py
+++ b/FaaSr_py/s3_api/log.py
@@ -75,6 +75,7 @@ def faasr_log(faasr_payload, log_message):
         with open(log_download_path, "a") as f:
             f.write(logs)
 
+        logger.info(f"This is the info: {faasr_payload["DataStores"]}")
 
         # Upload log back to S3
         try:

--- a/FaaSr_py/s3_api/log.py
+++ b/FaaSr_py/s3_api/log.py
@@ -75,7 +75,6 @@ def faasr_log(faasr_payload, log_message):
         with open(log_download_path, "a") as f:
             f.write(logs)
 
-        logger.info(f"This is the payload, just to confirm it exists: {faasr_payload}")
 
         # Upload log back to S3
         try:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ faasr/gcp-r:latest (R)
 faasr/slurm-python:latest (Python)
 faasr/slurm-r:latest (R)
 ```
+### Kubernetes
+```
+faasr/kubernets-python:dev (Python)
+faasr/kubernetes-r:dev (R)
+```
 ### AWS Lambda
 ```
 Email cutlern [at] oregonstate.edu or build your own

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ faasr/slurm-r:latest (R)
 ```
 ### Kubernetes
 ```
-faasr/kubernets-python:dev (Python)
+faasr/kubernetes-python:dev (Python)
 faasr/kubernetes-r:dev (R)
 ```
 ### AWS Lambda


### PR DESCRIPTION
These are the basic changes I made to allow the backend to work with Kubernetes. Most of this is in-line with the other implementations. The most important functions are the new helpers in _kubernetes_helper.py_ and the _invoke_kubernetes_ function. 

The biggest change I need to make before this can be considered complete is to remove the "verify=False" which is included in the call to make the POST request in _make_kubernetes_request_ in _kubernetes_helper.py_. This is only included as the NRP Kubernetes cluster I am testing with uses self-signed certificates (along with local instances). There is a way to solve this issue, but it is about implementing a way to specify a certificate authority in the FaaSr config, and then ensuring the request has access to the certificate for https verification. I will work on fixing this and adding it to the pull request when I am finished.

If there are any other changes I should make, please let me know!