### PR TITLE
install pip packages in /tmp/packages

### DIFF
--- a/FaaSr_py/engine/executor.py
+++ b/FaaSr_py/engine/executor.py
@@ -102,7 +102,7 @@ class Executor:
 
             if func_res != 0:
                 raise RuntimeError(
-                    f"non-zero exit code ({func_res!r}) from user function"
+                    f"non-zero exit code ({func_res!r}) from user function\nstdout: {func_stdout}"
                 )
         else:
             logger.info("SKIPPING USER FUNCTION")

--- a/FaaSr_py/helpers/faasr_start_invoke_helper.py
+++ b/FaaSr_py/helpers/faasr_start_invoke_helper.py
@@ -250,7 +250,7 @@ def faasr_pip_install(package):
     if not package:
         logger.info("No PyPI package dependency")
     else:
-        command = ["pip", "install", "--no-input", package]
+        command = ["pip", "install",  "--no-input", package, "-t", "/tmp/packages"]
         subprocess.run(command, text=True)
 
 

--- a/FaaSr_py/helpers/py_func_helper.py
+++ b/FaaSr_py/helpers/py_func_helper.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import logging
 import os
 import sys
@@ -70,6 +71,7 @@ def faasr_import_function_walk(func_name, directory="."):
         "faasr_start_invoke_github_actions.py",
     ]
     directory = os.path.abspath(directory)
+    importlib.invalidate_caches()
 
     if directory not in sys.path:
         sys.path.insert(0, directory)


### PR DESCRIPTION
Adds an argument to pip installs to change package directory to /tmp/packages, allowing python workflows to install packages correctly on AWS Lambda.