### PR TITLE
Fix .tolower() typo in faasr_get_s3_creds (str has no 'tolower' method)

### DIFF
--- a/FaaSr_py/s3_api/get_s3_creds.py
+++ b/FaaSr_py/s3_api/get_s3_creds.py
@@ -29,7 +29,7 @@ def faasr_get_s3_creds(faasr_payload, server_name=""):
     if not target_s3.get("Anonymous") or len(target_s3["Anonymous"]) == 0:
         anonymous = False
     else:
-        match (target_s3["Anonymous"].tolower()):
+        match (target_s3["Anonymous"].lower()):
             case "true":
                 anonymous = True
             case "false":


### PR DESCRIPTION
Any DataStore with a non-empty 'Anonymous' field crashes faasr_get_s3_creds with AttributeError: 'str' object has no attribute 'tolower'. Python's str method is .lower(), not .tolower(). Triggers in faasr_arrow_s3_bucket and any FaaSr workflow using anonymous DataStores.